### PR TITLE
Feature/ZAT-2 - seo external no follow

### DIFF
--- a/src/components/ArrowLink/ArrowLink.js
+++ b/src/components/ArrowLink/ArrowLink.js
@@ -7,7 +7,7 @@ import {
 } from './ArrowLink.styled';
 
 export const ArrowLink = ({
-  customAs, children, href, onClick, to, type, ...props
+  customAs, children, href, rel, onClick, to, type, ...props
 }) => {
   if (customAs === 'div') {
     return (
@@ -36,6 +36,7 @@ export const ArrowLink = ({
     return (
       <ExternalLink
         href={href}
+        rel={rel}
         {...props}
       >
         {children}
@@ -64,6 +65,7 @@ ArrowLink.propTypes = {
   ]).isRequired,
   customAs: PropTypes.string,
   href: PropTypes.string,
+  rel: PropTypes.string,
   onClick: PropTypes.func,
   to: PropTypes.string,
   type: PropTypes.string,
@@ -74,6 +76,7 @@ ArrowLink.defaultProps = {
   $isCaps: false,
   customAs: null,
   href: null,
+  rel: null,
   onClick: null,
   to: null,
   type: 'button',

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const ExternalLink = ({
-  children, href, rel='noreferrer', ...props
+  children, href, rel = 'noreferrer', ...props
 }) => (
   <a
     href={href}
@@ -21,4 +21,8 @@ ExternalLink.propTypes = {
   ]).isRequired,
   href: PropTypes.string.isRequired,
   rel: PropTypes.string,
+};
+
+ExternalLink.defaultProps = {
+  rel: 'noreferrer'
 };

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const ExternalLink = ({
-  children, href, ...props
+  children, href, rel='noreferrer', ...props
 }) => (
   <a
     href={href}
-    rel="noreferrer"
+    rel={rel}
     target="_blank"
     {...props}
   >
@@ -20,4 +20,5 @@ ExternalLink.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
   href: PropTypes.string.isRequired,
+  rel: PropTypes.string,
 };

--- a/src/components/GlobalFooter/GlobalFooter.js
+++ b/src/components/GlobalFooter/GlobalFooter.js
@@ -87,6 +87,7 @@ export const GlobalFooter = ({
                 <ExternalLink
                   href={link.url}
                   key={link.title}
+                  rel={`noreferrer nofollow`}
                 >
                   {link.title}
                 </ExternalLink>

--- a/src/components/GlobalFooter/GlobalFooter.js
+++ b/src/components/GlobalFooter/GlobalFooter.js
@@ -87,7 +87,7 @@ export const GlobalFooter = ({
                 <ExternalLink
                   href={link.url}
                   key={link.title}
-                  rel={`noreferrer nofollow`}
+                  rel="noreferrer nofollow"
                 >
                   {link.title}
                 </ExternalLink>

--- a/src/components/Post/Footnotes.js
+++ b/src/components/Post/Footnotes.js
@@ -19,7 +19,10 @@ const renderFootnotes = content => {
           const isLink = footnote.startsWith('http');
           const item = isLink ?
             (
-              <ExternalLink href={footnote} rel="noreferrer nofollow">
+              <ExternalLink
+                href={footnote}
+                rel="noreferrer nofollow"
+              >
                 {footnote}
               </ExternalLink>
             ) :

--- a/src/components/Post/Footnotes.js
+++ b/src/components/Post/Footnotes.js
@@ -19,7 +19,7 @@ const renderFootnotes = content => {
           const isLink = footnote.startsWith('http');
           const item = isLink ?
             (
-              <ExternalLink href={footnote}>
+              <ExternalLink href={footnote} rel="noreferrer nofollow">
                 {footnote}
               </ExternalLink>
             ) :

--- a/src/components/ProductPage/Header/Header.js
+++ b/src/components/ProductPage/Header/Header.js
@@ -87,7 +87,7 @@ export const Header = ({
               <ArrowLink
                 href={link.url}
                 key={link.title}
-                rel="noreferrer"
+                rel="noreferrer nofollow"
                 target="_blank"
               >
                 {link.title}


### PR DESCRIPTION
Added support for rel attribute in ExternalLink and ArrowLink components with default value to 'noreferrer' for backward compatibility. Also added 'nofollow' rel for SEO selected external links - footer, product and post